### PR TITLE
Support multiple "python qt" api names

### DIFF
--- a/pyqode/qt/QtCore.py
+++ b/pyqode/qt/QtCore.py
@@ -8,7 +8,7 @@ from pyqode.qt import PYQT4_API
 from pyqode.qt import PYSIDE_API
 
 
-if os.environ[QT_API] == PYQT5_API:
+if os.environ[QT_API] in PYQT5_API:
     from PyQt5.QtCore import *
     # compatibility with pyside
     from PyQt5.QtCore import pyqtSignal as Signal
@@ -16,7 +16,7 @@ if os.environ[QT_API] == PYQT5_API:
     from PyQt5.QtCore import pyqtProperty as Property
     # use a common __version__
     from PyQt5.QtCore import QT_VERSION_STR as __version__
-elif os.environ[QT_API] == PYQT4_API:
+elif os.environ[QT_API] in PYQT4_API:
     from PyQt4.QtCore import *
     # compatibility with pyside
     from PyQt4.QtCore import pyqtSignal as Signal
@@ -25,7 +25,7 @@ elif os.environ[QT_API] == PYQT4_API:
     from PyQt4.QtGui import QSortFilterProxyModel
     # use a common __version__
     from PyQt4.QtCore import QT_VERSION_STR as __version__
-elif os.environ[QT_API] == PYSIDE_API:
+elif os.environ[QT_API] in PYSIDE_API:
     from PySide.QtCore import *
     from PySide.QtGui import QSortFilterProxyModel
     # use a common __version__

--- a/pyqode/qt/QtDesigner.py
+++ b/pyqode/qt/QtDesigner.py
@@ -7,7 +7,7 @@ from pyqode.qt import PYQT5_API
 from pyqode.qt import PYQT4_API
 
 
-if os.environ[QT_API] == PYQT5_API:
+if os.environ[QT_API] in PYQT5_API:
     from PyQt5.QtDesigner import *
-elif os.environ[QT_API] == PYQT4_API:
+elif os.environ[QT_API] in PYQT4_API:
     from PyQt4.QtDesigner import *

--- a/pyqode/qt/QtGui.py
+++ b/pyqode/qt/QtGui.py
@@ -12,9 +12,9 @@ from pyqode.qt import PYQT4_API
 from pyqode.qt import PYSIDE_API
 
 
-if os.environ[QT_API] == PYQT5_API:
+if os.environ[QT_API] in PYQT5_API:
     from PyQt5.QtGui import *
-elif os.environ[QT_API] == PYQT4_API:
+elif os.environ[QT_API] in PYQT4_API:
     from PyQt4.QtGui import *
-elif os.environ[QT_API] == PYSIDE_API:
+elif os.environ[QT_API] in PYSIDE_API:
     from PySide.QtGui import *

--- a/pyqode/qt/QtNetwork.py
+++ b/pyqode/qt/QtNetwork.py
@@ -7,9 +7,9 @@ from pyqode.qt import PYQT5_API
 from pyqode.qt import PYQT4_API
 from pyqode.qt import PYSIDE_API
 
-if os.environ[QT_API] == PYQT5_API:
+if os.environ[QT_API] in PYQT5_API:
     from PyQt5.QtNetwork import *
-elif os.environ[QT_API] == PYQT4_API:
+elif os.environ[QT_API] in PYQT4_API:
     from PyQt4.QtNetwork import *
-elif os.environ[QT_API] == PYSIDE_API:
+elif os.environ[QT_API] in PYSIDE_API:
     from PySide.QtNetwork import *

--- a/pyqode/qt/QtTest.py
+++ b/pyqode/qt/QtTest.py
@@ -11,14 +11,14 @@ from pyqode.qt import PYQT5_API
 from pyqode.qt import PYQT4_API
 from pyqode.qt import PYSIDE_API
 
-if os.environ[QT_API] == PYQT5_API:
+if os.environ[QT_API] in PYQT5_API:
     from PyQt5.QtTest import QTest
-elif os.environ[QT_API] == PYQT4_API:
+elif os.environ[QT_API] in PYQT4_API:
     from PyQt4.QtTest import QTest as OldQTest
 
     class QTest(OldQTest):
         @staticmethod
         def qWaitForWindowActive(QWidget):
             OldQTest.qWaitForWindowShown(QWidget)
-elif os.environ[QT_API] == PYSIDE_API:
+elif os.environ[QT_API] in PYSIDE_API:
     raise ImportError('QtTest support is incomplete for PySide')

--- a/pyqode/qt/QtWidgets.py
+++ b/pyqode/qt/QtWidgets.py
@@ -11,14 +11,14 @@ from pyqode.qt import PYQT5_API
 from pyqode.qt import PYQT4_API
 from pyqode.qt import PYSIDE_API
 
-
-if os.environ[QT_API] == PYQT5_API:
+if os.environ[QT_API] in PYQT5_API:
     from PyQt5.QtWidgets import *
-elif os.environ[QT_API] == PYQT4_API:
+elif os.environ[QT_API] in PYQT4_API:
     from PyQt4.QtGui import *
     from PyQt4.QtGui import QFileDialog as OldFileDialog
 
     class QFileDialog(OldFileDialog):
+
         @staticmethod
         def getOpenFileName(parent=None, caption='', directory='',
                             filter='', selectedFilter='',
@@ -42,5 +42,5 @@ elif os.environ[QT_API] == PYQT4_API:
             return OldFileDialog.getSaveFileNameAndFilter(
                 parent, caption, directory, filter, selectedFilter,
                 options)
-elif os.environ[QT_API] == PYSIDE_API:
+elif os.environ[QT_API] in PYSIDE_API:
     from PySide.QtGui import *

--- a/pyqode/qt/__init__.py
+++ b/pyqode/qt/__init__.py
@@ -57,15 +57,19 @@ __version__ = '2.5.dev1'
 
 #: Qt API environment variable name
 QT_API = 'QT_API'
-#: name of the expected PyQt5 api
-PYQT5_API = 'pyqt5'
-#: name of the expected PyQt4 api
-PYQT4_API = 'pyqt4'
-#: name of the expected PySide api
-PYSIDE_API = 'pyside'
+#: names of the expected PyQt5 api
+PYQT5_API = ['pyqt5']
+#: names of the expected PyQt4 api
+PYQT4_API = [
+    'pyqt',  # name used in IPython.qt
+    'pyqt4'  # pyqode.qt original name
+]
+#: names of the expected PySide api
+PYSIDE_API = ['pyside']
 
 
 class PythonQtError(Exception):
+
     """
     Error raise if no bindings could be selected
     """
@@ -103,20 +107,20 @@ def autodetect():
     try:
         logging.getLogger(__name__).debug('trying PyQt5')
         import PyQt5
-        os.environ[QT_API] = PYQT5_API
+        os.environ[QT_API] = PYQT5_API[0]
         logging.getLogger(__name__).debug('imported PyQt5')
     except ImportError:
         try:
             logging.getLogger(__name__).debug('trying PyQt4')
             setup_apiv2()
             import PyQt4
-            os.environ[QT_API] = PYQT4_API
+            os.environ[QT_API] = PYQT4_API[0]
             logging.getLogger(__name__).debug('imported PyQt4')
         except ImportError:
             try:
                 logging.getLogger(__name__).debug('trying PySide')
                 import PySide
-                os.environ[QT_API] = PYSIDE_API
+                os.environ[QT_API] = PYSIDE_API[0]
                 logging.getLogger(__name__).debug('imported PySide')
             except ImportError:
                 raise PythonQtError('No Qt bindings could be found')
@@ -125,21 +129,21 @@ def autodetect():
 if QT_API in os.environ:
     # check if the selected QT_API is available
     try:
-        if os.environ[QT_API].lower() == PYQT5_API.lower():
+        if os.environ[QT_API].lower() in PYQT5_API:
             logging.getLogger(__name__).debug('importing PyQt5')
             import PyQt5
-            os.environ[QT_API] = PYQT5_API
+            os.environ[QT_API] = PYQT5_API[0]
             logging.getLogger(__name__).debug('imported PyQt5')
-        elif os.environ[QT_API].lower() == PYQT4_API.lower():
+        elif os.environ[QT_API].lower() in PYQT4_API:
             logging.getLogger(__name__).debug('importing PyQt4')
             setup_apiv2()
             import PyQt4
-            os.environ[QT_API] = PYQT4_API
+            os.environ[QT_API] = PYQT4_API[0]
             logging.getLogger(__name__).debug('imported PyQt4')
-        elif os.environ[QT_API].lower() == PYSIDE_API.lower():
+        elif os.environ[QT_API].lower() in PYSIDE_API:
             logging.getLogger(__name__).debug('importing PySide')
             import PySide
-            os.environ[QT_API] = PYSIDE_API
+            os.environ[QT_API] = PYSIDE_API[0]
             logging.getLogger(__name__).debug('imported PySide')
     except ImportError:
         logging.getLogger(__name__).warning(


### PR DESCRIPTION
For example, in pyqode name for PyQt4 api is "pyqt4", whereas IPython api name is "pyqt"
This patch support both names. Multiple name support is also available for PySide and PyQt5.